### PR TITLE
Change baseurl in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This theme relies heavily on a well crafted `config.toml` file.  It will consist
 These parameters are required for the theme to compile and function correctly.
 
 ```toml
-baseurl = "http://replace-this-with-your-hugo-site.com/"
+baseurl = "https://www.example.com/"
 languageCode = "en-us"
 title = "Own the Web"
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseurl                 = "http://replace-this-with-your-hugo-site.com/"
+baseurl                 = "https://www.example.com/"
 languageCode            = "en-us"
 title                   = "Hugo Phlat Theme"
 theme                   = "hugo-phlat-theme"


### PR DESCRIPTION
Avoids the abuse of potential scamming under the default base url. See spf13/hugoThemes#171.

Closes #7
